### PR TITLE
Fix a navigation problem

### DIFF
--- a/ContainerManager/ContainerViewSegueManager.swift
+++ b/ContainerManager/ContainerViewSegueManager.swift
@@ -38,7 +38,7 @@ open class ContainerViewSegueManager: UIViewController {
     // MARK: - Class setup
     
     /// Call to class setup
-    override open func viewWillAppear(_ animated: Bool) {
+    override open func viewDidLoad() {
         self.setupDataManagerClass(containerDataClass!)
     }
     


### PR DESCRIPTION
Because a problem in navigation with degation pattern (ex: UIImagePickerController). The container was recreating the Viewcontroller and losing the delegate's reference.